### PR TITLE
Add methods for pageload waiting and element presence checking

### DIFF
--- a/src/main/java/framework/Config.java
+++ b/src/main/java/framework/Config.java
@@ -22,11 +22,8 @@ public class Config {
 
         System.setProperty("webdriver.gecko.driver", System.getenv("GECKO_PATH"));
 
-        System.setProperty("headless", "false");
-        String headless = System.getProperty("headless");
-
         FirefoxDriverManager.firefoxdriver();
-        if ("true".equals(headless)) {
+        if (System.getenv("HEADLESS").equals("true")) {
             FirefoxOptions firefoxOptions = new FirefoxOptions();
             firefoxOptions.addArguments("--headless");
             driver = new FirefoxDriver(firefoxOptions);

--- a/src/main/java/framework/Helpers.java
+++ b/src/main/java/framework/Helpers.java
@@ -2,8 +2,12 @@ package framework;
 
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.By;
 import org.openqa.selenium.support.PageFactory;
 import org.openqa.selenium.support.pagefactory.AjaxElementLocatorFactory;
+import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
@@ -12,11 +16,20 @@ public class Helpers {
     private static final int TIMEOUT = 5;
     private static final int POLLING = 100;
 
+    protected WebDriver driver;
+
     private WebDriverWait wait;
 
     public Helpers(WebDriver driver) {
         wait = new WebDriverWait(driver, TIMEOUT, POLLING);
         PageFactory.initElements(new AjaxElementLocatorFactory(driver, TIMEOUT), this);
+        this.driver = driver;
+    }
+
+    public void waitForPageLoad() {
+        ExpectedCondition<Boolean> pageLoadCondition = driver -> ((JavascriptExecutor) driver).executeScript("return document.readyState").equals("complete");
+        WebDriverWait wait = new WebDriverWait(driver, 30);
+        wait.until(pageLoadCondition);
     }
 
     protected void waitForElementToAppear(WebElement element) {
@@ -29,5 +42,14 @@ public class Helpers {
 
     protected void waitForTextToDisappear(WebElement element, String text) {
         wait.until(ExpectedConditions.not(ExpectedConditions.textToBePresentInElement(element, text)));
+    }
+
+    protected boolean doesElementExist(String id) {
+        try {
+            driver.findElement(By.id(id));
+        } catch (NoSuchElementException e) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/pageobjects/Google.java
+++ b/src/main/java/pageobjects/Google.java
@@ -2,6 +2,7 @@ package pageobjects;
 
 import framework.Helpers;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -12,7 +13,7 @@ public class Google extends Helpers {
     @FindBy(xpath = "//input[@title='Пребарајте']")
     private WebElement searchField;
 
-    @FindBy(xpath = "//div[@id='topabar']")
+    @FindBy(xpath = "//div[@id='resultStats']")
     private WebElement searchResultsPageHeader;
 
     public Google(WebDriver driver) {
@@ -24,5 +25,10 @@ public class Google extends Helpers {
         searchField.sendKeys(query);
         searchField.sendKeys(Keys.ENTER);
         this.waitForElementToAppear(searchResultsPageHeader);
+    }
+
+    public void selectSearchResult(String searchResultUrl) {
+        driver.findElement(By.xpath("//a[@href=\"" + searchResultUrl + "\"]")).click();
+        this.waitForPageLoad();
     }
 }

--- a/src/test/java/testsuite/DummyTest.java
+++ b/src/test/java/testsuite/DummyTest.java
@@ -9,6 +9,7 @@ public class DummyTest extends Config {
     @Test
     public void googleTest() {
 
-        google.enterAndSubmitSearch("Hello, automation!");
+        google.enterAndSubmitSearch("Twitter");
+        google.selectSearchResult("https://twitter.com/");
     }
 }


### PR DESCRIPTION
## Issue/Motivation

To reliably interact with elements and perform assertions, it's good to wait for the page to be properly loaded first.
In addition, it's good to have a generic method that checks for element presence, to avoid redundancy and stick to DRY.

## Changes

1. Refactors `headless` check into a system variable.
2. Adds a method that waits for pageload.
3. Adds a method that checks for element presence via `id`.