### PR TITLE
Update PO instatiation to be per-test, and bump Java version to 14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,22 @@
     <artifactId>chris-auto</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <properties>
+        <maven.compiler.release>14</maven.compiler.release>
+    </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
     <dependencies>
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
         <dependency>

--- a/src/main/java/framework/Config.java
+++ b/src/main/java/framework/Config.java
@@ -8,19 +8,14 @@ import org.openqa.selenium.firefox.FirefoxOptions;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
 
-import pageobjects.*;
-
 public class Config {
 
-    private WebDriver driver;
-
-    protected Helpers helpers;
-    protected Google google;
+    protected WebDriver driver;
 
     @BeforeSuite(alwaysRun = true)
     public void beforeSuite() {
 
-        System.setProperty("webdriver.gecko.driver", System.getenv("GECKO_PATH"));
+        System.setProperty("webdriver.gecko.driver", "src/main/resources/drivers/geckodriver.exe");
 
         FirefoxDriverManager.firefoxdriver();
         if (System.getenv("HEADLESS").equals("true")) {
@@ -32,9 +27,6 @@ public class Config {
         }
 
         driver.get(System.getenv("BASEURL"));
-
-        helpers = new Helpers(driver);
-        google = new Google(driver);
     }
 
     @AfterSuite

--- a/src/main/java/framework/Helpers.java
+++ b/src/main/java/framework/Helpers.java
@@ -16,9 +16,9 @@ public class Helpers {
     private static final int TIMEOUT = 5;
     private static final int POLLING = 100;
 
-    protected WebDriver driver;
+    protected final WebDriver driver;
 
-    private WebDriverWait wait;
+    private final WebDriverWait wait;
 
     public Helpers(WebDriver driver) {
         wait = new WebDriverWait(driver, TIMEOUT, POLLING);
@@ -27,7 +27,7 @@ public class Helpers {
     }
 
     public void waitForPageLoad() {
-        ExpectedCondition<Boolean> pageLoadCondition = driver -> ((JavascriptExecutor) driver).executeScript("return document.readyState").equals("complete");
+        ExpectedCondition<Boolean> pageLoadCondition = driver -> driver != null && ((JavascriptExecutor) driver).executeScript("return document.readyState").equals("complete");
         WebDriverWait wait = new WebDriverWait(driver, 30);
         wait.until(pageLoadCondition);
     }

--- a/src/main/java/pageobjects/Google.java
+++ b/src/main/java/pageobjects/Google.java
@@ -13,7 +13,7 @@ public class Google extends Helpers {
     @FindBy(xpath = "//input[@title='Пребарајте']")
     private WebElement searchField;
 
-    @FindBy(xpath = "//div[@id='resultStats']")
+    @FindBy(xpath = "//div[@id='appbar']")
     private WebElement searchResultsPageHeader;
 
     public Google(WebDriver driver) {

--- a/src/test/java/testsuite/DummyTest.java
+++ b/src/test/java/testsuite/DummyTest.java
@@ -2,9 +2,19 @@ package testsuite;
 
 import framework.Config;
 
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import pageobjects.Google;
+
 public class DummyTest extends Config {
+
+    Google google;
+
+    @BeforeTest
+    public void init() {
+        google = new Google(driver);
+    }
 
     @Test
     public void googleTest() {


### PR DESCRIPTION
## Issue/Motivation

To better handle memory usage, there's no reason for every single page object to be instantiated for every test class. Instead, they should be instantiated per-test, and only the ones that are actually needed.
Additionally, newer Java versions have some nifty features to play around with, so bumping the version to 14.

## Changes

1. Bumps Java version to 14.
2. Instantiates page object per-test, as opposed to via a centralized config file.