### PR TITLE
Fetch Geckodriver path via env variable

### DIFF
--- a/src/main/java/framework/Config.java
+++ b/src/main/java/framework/Config.java
@@ -24,7 +24,7 @@ public class Config {
 
     @BeforeMethod(alwaysRun = true)
     public void setUp() {
-        System.setProperty("webdriver.gecko.driver", "src/main/resources/drivers/geckodriver.exe");
+        System.setProperty("webdriver.gecko.driver", System.getenv("GECKOPATH"));
         FirefoxDriverManager.firefoxdriver();
         if (System.getenv("HEADLESS").equals("true")) {
             FirefoxOptions firefoxOptions = new FirefoxOptions();


### PR DESCRIPTION
## Issue/Motivation

In order to be able to run the tests in different environments, the geckodriver path needs to be dynamic. This can be done by turning it in to an environment variable.

## Changes

1. Add GECKOPATH variable.