### PR TITLE
Add Log4j properties file

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=ERROR, consoleAppender
+
+log4j.appender.consoleAppender=org.apache.log4j.ConsoleAppender
+log4j.appender.consoleAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.consoleAppender.layout.ConversionPattern=[%t] %-5p %c %x - %m%n


### PR DESCRIPTION
### Issue / Motivation / Current Behavior

_LOG4J is throwing a lot of errors in the logs due to a missing properties file._

### Changes

_Adds `.properties` file for LOG4J._
