### PR TITLE
Use proper thread-safe driver

### DIFF
--- a/src/main/java/framework/TestBase.java
+++ b/src/main/java/framework/TestBase.java
@@ -8,11 +8,17 @@ import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.support.ThreadGuard;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 
 public class TestBase {
 
-    protected WebDriver driver;
+    public static ThreadLocal<WebDriver> driver = new ThreadLocal<>();
+
+    protected WebDriver getDriver() {
+        return driver.get();
+    }
 
     @BeforeClass(alwaysRun = true)
     public void retryHandler(ITestContext context) {
@@ -21,18 +27,20 @@ public class TestBase {
         }
     }
 
+    @BeforeMethod
     public void setUp() {
         WebDriverManager.firefoxdriver().setup();
         FirefoxOptions firefoxOptions = new FirefoxOptions();
-        System.setProperty(FirefoxDriver.SystemProperty.BROWSER_LOGFILE,"/dev/null");
+        System.setProperty(FirefoxDriver.SystemProperty.BROWSER_LOGFILE, "/dev/null");
         if (System.getenv("HEADLESS").equals("true")) {
             firefoxOptions.addArguments("--headless");
         }
-        driver = ThreadGuard.protect(new FirefoxDriver(firefoxOptions));
-        driver.get(System.getenv("BASEURL"));
+        driver.set(ThreadGuard.protect(new FirefoxDriver(firefoxOptions)));
+        getDriver().get(System.getenv("BASEURL"));
     }
 
+    @AfterMethod
     public void tearDown() {
-        driver.quit();
+        getDriver().quit();
     }
 }

--- a/src/test/java/testsuite/DemoTestOne.java
+++ b/src/test/java/testsuite/DemoTestOne.java
@@ -12,9 +12,7 @@ public class DemoTestOne extends TestBase {
     @Test
     public void createUserOne() {
 
-        setUp();
-
-        DemoRegistrationPage demoRegistrationPage = new DemoRegistrationPage(driver);
+        DemoRegistrationPage demoRegistrationPage = new DemoRegistrationPage(getDriver());
         demoRegistrationPage.navigateToRegistration();
         demoRegistrationPage.enterFirstAndLastName();
         demoRegistrationPage.enterAddress("1626 Bedford Avenue, Brooklyn, NY 11225");
@@ -29,7 +27,5 @@ public class DemoTestOne extends TestBase {
         demoRegistrationPage.submitInformation();
 
         Assert.assertTrue(demoRegistrationPage.isUsersTablePresent());
-
-        tearDown();
     }
 }

--- a/src/test/java/testsuite/DemoTestTwo.java
+++ b/src/test/java/testsuite/DemoTestTwo.java
@@ -1,8 +1,10 @@
 package testsuite;
 
 import framework.TestBase;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
 import pages.DemoRegistrationPage;
 
 public class DemoTestTwo extends TestBase {
@@ -10,9 +12,7 @@ public class DemoTestTwo extends TestBase {
     @Test
     public void createUserTwo() {
 
-        setUp();
-
-        DemoRegistrationPage demoRegistrationPage = new DemoRegistrationPage(driver);
+        DemoRegistrationPage demoRegistrationPage = new DemoRegistrationPage(getDriver());
         demoRegistrationPage.navigateToRegistration();
         demoRegistrationPage.enterFirstAndLastName();
         demoRegistrationPage.enterAddress("1626 Bedford Avenue, Brooklyn, NY 11225");
@@ -27,7 +27,5 @@ public class DemoTestTwo extends TestBase {
         demoRegistrationPage.submitInformation();
 
         Assert.assertTrue(demoRegistrationPage.isUsersTablePresent());
-
-        tearDown();
     }
 }


### PR DESCRIPTION
### Issue / Motivation / Current Behavior

_The previous implementation was sorta "natively" thread-safe by virtue of invoking `setUp` and `tearDown` manually in each test. This should work a little better, as it is thread-safe without such invocations.

### Changes

_1. Do not invoke `setUp` and `tearDown` manually, instead use thread-safe driver objects._
