### PR TITLE
Implement browser factory & update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>chris-auto</groupId>
-    <artifactId>chris-auto</artifactId>
+    <groupId>java-automation-framework</groupId>
+    <artifactId>java-automation-framework</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <properties>
@@ -35,47 +35,42 @@
     </build>
 
     <dependencies>
+        <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.22</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.28</version>
+            <version>1.7.36</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-log4j12 -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.28</version>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-firefox-driver -->
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-firefox-driver</artifactId>
-            <version>3.141.59</version>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-server -->
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-server</artifactId>
-            <version>3.141.59</version>
+            <version>1.7.36</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-java -->
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>3.141.59</version>
+            <version>4.1.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/io.github.bonigarcia/webdrivermanager -->
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>3.7.1</version>
+            <version>5.1.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.testng/testng -->
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.0.0</version>
+            <version>7.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.github.javafaker/javafaker -->
         <dependency>
@@ -84,5 +79,4 @@
             <version>1.0.2</version>
         </dependency>
     </dependencies>
-
 </project>

--- a/src/main/java/framework/AnnotationTransformer.java
+++ b/src/main/java/framework/AnnotationTransformer.java
@@ -1,0 +1,22 @@
+package framework;
+
+import org.testng.IAnnotationTransformer;
+import org.testng.annotations.ITestAnnotation;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+/**
+ * Allows for the configuration and modification of TestNG annotations during runtime.
+ */
+public class AnnotationTransformer implements IAnnotationTransformer {
+
+    /**
+     * Invokes transform method for each test during a test run, adding a retry for each failed test.
+     */
+    @Override
+    public void transform(ITestAnnotation annotation, Class testClass, Constructor testConstructor, Method testMethod) {
+
+        annotation.setRetryAnalyzer(RetryAnalyzer.class);
+    }
+}

--- a/src/main/java/framework/BasePage.java
+++ b/src/main/java/framework/BasePage.java
@@ -1,50 +1,58 @@
 package framework;
 
+import framework.driver.WebDriverManager;
+
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.support.PageFactory;
-import org.openqa.selenium.support.pagefactory.AjaxElementLocatorFactory;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
+import java.time.Duration;
+
 public class BasePage {
 
     private static final int TIMEOUT = 5;
-    private static final int POLLING = 100;
+    private static final int POLLING_INTERVAL = 100;
 
     protected final WebDriver driver;
 
     private final WebDriverWait wait;
 
-    public BasePage(WebDriver driver) {
-        wait = new WebDriverWait(driver, TIMEOUT, POLLING);
-        PageFactory.initElements(new AjaxElementLocatorFactory(driver, TIMEOUT), this);
-        this.driver = driver;
+    public BasePage() {
+
+        driver = WebDriverManager.getDriver();
+        wait = new WebDriverWait(driver, Duration.ofSeconds(TIMEOUT), Duration.ofMillis(POLLING_INTERVAL));
+        PageFactory.initElements(driver, this);
     }
 
     public void waitForPageLoad() {
+
         ExpectedCondition<Boolean> pageLoadCondition = driver -> driver != null && ((JavascriptExecutor) driver).executeScript("return document.readyState").equals("complete");
-        WebDriverWait wait = new WebDriverWait(driver, 30);
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(30));
         wait.until(pageLoadCondition);
     }
 
     protected void waitForElementToAppear(WebElement element) {
+
         wait.until(ExpectedConditions.visibilityOf(element));
     }
 
     protected void waitForElementToDisappear(WebElement element) {
+
         wait.until(ExpectedConditions.invisibilityOf(element));
     }
 
     protected void waitForTextToDisappear(WebElement element, String text) {
+
         wait.until(ExpectedConditions.not(ExpectedConditions.textToBePresentInElement(element, text)));
     }
 
     protected void dropdownSelectByVisibleText(WebElement element, String text) {
-        Select selectSkill = new Select(element);
-        selectSkill.selectByVisibleText(text);
+
+        new Select(element).selectByVisibleText(text);
     }
 }

--- a/src/main/java/framework/BaseTest.java
+++ b/src/main/java/framework/BaseTest.java
@@ -1,46 +1,32 @@
 package framework;
 
-import io.github.bonigarcia.wdm.WebDriverManager;
+import framework.driver.*;
 
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.firefox.FirefoxOptions;
-import org.openqa.selenium.support.ThreadGuard;
-import org.testng.ITestContext;
-import org.testng.ITestNGMethod;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
 
 public class BaseTest {
 
-    public static ThreadLocal<WebDriver> driver = new ThreadLocal<>();
-
-    protected WebDriver getDriver() {
-        return driver.get();
-    }
-
-    @BeforeClass(alwaysRun = true)
-    public void retryHandler(ITestContext context) {
-        for (ITestNGMethod method : context.getAllTestMethods()) {
-            method.setRetryAnalyzerClass(Retry.class);
-        }
-    }
-
+    /**
+     * Starts an instance of this browser type.
+     *
+     * @param browser the type of browser instance to start; defaults to "chrome" if not provided in TestNG XML
+     */
+    @Parameters({"browser"})
     @BeforeMethod
-    public void setUp() {
-        WebDriverManager.firefoxdriver().setup();
-        FirefoxOptions firefoxOptions = new FirefoxOptions();
-        System.setProperty(FirefoxDriver.SystemProperty.BROWSER_LOGFILE, "/dev/null");
-        if (System.getenv("HEADLESS").equals("true")) {
-            firefoxOptions.addArguments("--headless");
-        }
-        driver.set(ThreadGuard.protect(new FirefoxDriver(firefoxOptions)));
-        getDriver().get(System.getenv("BASEURL"));
+    public void setUp(@Optional("chrome") String browser) {
+
+        WebDriverManager.setWebDriver(WebDriverFactory.getDriver(BrowserType.fromValue(browser)));
     }
 
+    /**
+     * Quits the instance of the currently running browser type.
+     */
     @AfterMethod
     public void tearDown() {
-        getDriver().quit();
+
+        WebDriverManager.quitDriver();
     }
 }

--- a/src/main/java/framework/RetryAnalyzer.java
+++ b/src/main/java/framework/RetryAnalyzer.java
@@ -3,20 +3,22 @@ package framework;
 import org.testng.IRetryAnalyzer;
 import org.testng.ITestResult;
 
-public class Retry implements IRetryAnalyzer {
+public class RetryAnalyzer implements IRetryAnalyzer {
 
-    private int count = 0;
+    private int RETRY_COUNT = 0;
 
     public boolean retry(ITestResult result) {
-        if (count < 2) {
-            System.out.println("Retrying test " + result.getName() + " with status " + getResultStatusName(result.getStatus()) + " for the " + (count + 1) + " time(s).");
-            count++;
+
+        if (RETRY_COUNT < 2) {
+            System.out.println("Retrying test " + result.getName() + " with status " + getResultStatusName(result.getStatus()) + " for the " + (RETRY_COUNT + 1) + " time(s).");
+            RETRY_COUNT++;
             return true;
         }
         return false;
     }
 
     public String getResultStatusName(int status) {
+
         String resultName = null;
         if (status == 1)
             resultName = "SUCCESS";

--- a/src/main/java/framework/TestListener.java
+++ b/src/main/java/framework/TestListener.java
@@ -11,6 +11,7 @@ public class TestListener implements ITestListener {
 
     @Override
     public void onFinish(ITestContext context) {
+
         Set<ITestResult> failedTests = context.getFailedTests().getAllResults();
         for (ITestResult temp : failedTests) {
             ITestNGMethod method = temp.getMethod();
@@ -30,14 +31,17 @@ public class TestListener implements ITestListener {
     }
 
     public void onTestSuccess(ITestResult result) {
+
         System.out.println("PASSED: " + result.getTestClass().getName() + " ==> " + result.getName());
     }
 
     public void onTestFailure(ITestResult result) {
+
         System.out.println("FAILED: " + result.getTestClass().getName() + " ==> " + result.getName());
     }
 
     public void onTestSkipped(ITestResult result) {
+
         System.out.println("SKIPPED: " + result.getTestClass().getName() + " ==> " + result.getName());
     }
 

--- a/src/main/java/framework/driver/BrowserType.java
+++ b/src/main/java/framework/driver/BrowserType.java
@@ -1,0 +1,30 @@
+package framework.driver;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+@AllArgsConstructor
+public enum BrowserType {
+
+    FIREFOX("Firefox"),
+    CHROME("Chrome");
+
+    private final String name;
+
+    /**
+     * Gets an enum representation of this String value browser type. String value is case-insensitive.
+     *
+     * @param type String representation of browser type, for example "chrome"
+     * @return enum representation of browser type, for example CHROME
+     */
+    public static BrowserType fromValue(String type) {
+
+        return Arrays.stream(BrowserType.values())
+                .filter(browserType -> browserType.getName().equalsIgnoreCase(type))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown browser type: " + type));
+    }
+}

--- a/src/main/java/framework/driver/WebDriverFactory.java
+++ b/src/main/java/framework/driver/WebDriverFactory.java
@@ -1,0 +1,78 @@
+package framework.driver;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import io.github.bonigarcia.wdm.config.DriverManagerType;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeDriverService;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
+
+import java.time.Duration;
+
+public class WebDriverFactory {
+
+    private static final int DEFAULT_WAIT_IN_SECONDS = 30;
+
+    /**
+     * Sets the WebDriver to this browser type.
+     *
+     * @param browser String representation of browser type, for example "chrome"; String value is case-insensitive
+     * @return a WebDriver of the selected browser type
+     */
+    public static WebDriver getDriver(BrowserType browser) {
+
+        WebDriver driver = switch (browser) {
+            case CHROME -> getChrome();
+            case FIREFOX -> getFirefox();
+        };
+
+        driver.manage().window().fullscreen();
+        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10));
+        driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(DEFAULT_WAIT_IN_SECONDS));
+        return driver;
+    }
+
+    /**
+     * Sets up the Firefox WebDriver configuration.
+     *
+     * @return a Firefox WebDriver object
+     */
+    private static FirefoxDriver getFirefox() {
+
+        WebDriverManager.getInstance(DriverManagerType.FIREFOX).setup();
+        FirefoxOptions firefoxOptions = new FirefoxOptions();
+        firefoxOptions.addArguments("disable-gpu");
+        firefoxOptions.addArguments("--start-maximized");
+        return new FirefoxDriver(firefoxOptions);
+    }
+
+    /**
+     * Sets up the Chrome WebDriver configuration.
+     *
+     * @return a Chrome WebDriver object
+     */
+    private static ChromeDriver getChrome() {
+
+        WebDriverManager.getInstance(DriverManagerType.CHROME).setup();
+
+        System.setProperty(ChromeDriverService.CHROME_DRIVER_SILENT_OUTPUT_PROPERTY, "true");
+
+        ChromeOptions chromeOptions = new ChromeOptions();
+        chromeOptions.addArguments("--no-sandbox");
+        chromeOptions.addArguments("--disable-dev-shm-usage");
+        chromeOptions.addArguments("--no-proxy-server");
+
+        if (Boolean.parseBoolean(System.getenv("INCOGNITO"))) {
+            chromeOptions.addArguments("--incognito");
+        }
+
+        if (Boolean.parseBoolean(System.getenv("HEADLESS"))) {
+            chromeOptions.addArguments("--headless");
+            chromeOptions.addArguments("--window-size=1920,1080");
+        }
+        return new ChromeDriver(chromeOptions);
+    }
+}

--- a/src/main/java/framework/driver/WebDriverManager.java
+++ b/src/main/java/framework/driver/WebDriverManager.java
@@ -1,0 +1,40 @@
+package framework.driver;
+
+import org.openqa.selenium.WebDriver;
+
+public class WebDriverManager {
+
+    private static final ThreadLocal<WebDriver> threadLocalDriver = new ThreadLocal<>();
+
+    /**
+     * Gets the current thread’s instance of the WebDriver.
+     *
+     * @return the WebDriver instance of the current thread
+     */
+    public static WebDriver getDriver() {
+
+        return threadLocalDriver.get();
+    }
+
+    /**
+     * Sets the current thread’s instance of the WebDriver to this browser type.
+     *
+     * @param driverType the browser type of the WebDriver instance of the current thread
+     */
+    public static void setWebDriver(WebDriver driverType) {
+
+        threadLocalDriver.set(driverType);
+    }
+
+    /**
+     * Quits the current thread’s instance of the WebDriver.
+     */
+    public static void quitDriver() {
+
+        if (WebDriverManager.getDriver() != null) {
+            WebDriverManager.getDriver().close();
+            WebDriverManager.getDriver().quit();
+            threadLocalDriver.remove();
+        }
+    }
+}

--- a/src/main/java/pages/DemoRegistrationPage.java
+++ b/src/main/java/pages/DemoRegistrationPage.java
@@ -62,8 +62,8 @@ public class DemoRegistrationPage extends BasePage {
     @FindBy(xpath = "//div[@class='ui-grid-contents-wrapper']")
     private WebElement usersTable;
 
-    public DemoRegistrationPage(WebDriver driver) {
-        super(driver);
+    public DemoRegistrationPage() {
+        super();
         PageFactory.initElements(driver, this);
     }
 

--- a/src/test/java/testsuite/DemoTestOne.java
+++ b/src/test/java/testsuite/DemoTestOne.java
@@ -12,7 +12,7 @@ public class DemoTestOne extends BaseTest {
     @Test
     public void createUserOne() {
 
-        DemoRegistrationPage demoRegistrationPage = new DemoRegistrationPage(getDriver());
+        DemoRegistrationPage demoRegistrationPage = new DemoRegistrationPage();
         demoRegistrationPage.navigateToRegistration();
         demoRegistrationPage.enterFirstAndLastName();
         demoRegistrationPage.enterAddress("1626 Bedford Avenue, Brooklyn, NY 11225");

--- a/src/test/java/testsuite/DemoTestTwo.java
+++ b/src/test/java/testsuite/DemoTestTwo.java
@@ -12,7 +12,7 @@ public class DemoTestTwo extends BaseTest {
     @Test
     public void createUserTwo() {
 
-        DemoRegistrationPage demoRegistrationPage = new DemoRegistrationPage(getDriver());
+        DemoRegistrationPage demoRegistrationPage = new DemoRegistrationPage();
         demoRegistrationPage.navigateToRegistration();
         demoRegistrationPage.enterFirstAndLastName();
         demoRegistrationPage.enterAddress("1626 Bedford Avenue, Brooklyn, NY 11225");

--- a/testsuite.xml
+++ b/testsuite.xml
@@ -2,6 +2,7 @@
 <suite name="Testsuite" parallel="methods" thread-count="2">
     <listeners>
         <listener class-name="framework.TestListener"/>
+        <listener class-name="framework.AnnotationTransformer"/>
     </listeners>
     <test name="Test">
         <classes>


### PR DESCRIPTION
### Issue / Motivation / Current Behavior

_Previously the tests didn't really support different browser types, and instead were hardcoded to always use Firefox. This PR adds a browser factory pattern that allows for browser type setting, in addition to updating dependencies and other misc. cleanup to get the framework back in order._

### Changes

_1. Sets up browser factory pattern._
_2. Cleans up dependencies._
_3. Other misc. cleanup._
